### PR TITLE
Fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Software for SatNOGS project.
 This repository includes all custom made software components for SatNOGS project.
 
 More information can be found in our documentation page:
-http://satnogs.org/software.html
+https://satnogs.org/documentation/software


### PR DESCRIPTION
README.md was pointing to http://satnogs.org/software.html which
is 404. Fixed to https://satnogs.org/documentation/software